### PR TITLE
Debian metadata update

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,10 @@
-python-xtd (0.5.7) unstable; urgency=medium
+xtdpy (0.5.7) unstable; urgency=medium
 
   * fixes a bug in logging facility where record where modified by multiple filters
 
  -- Xavier MARCELET <xavier.marcelet@orange.com>  Wed, 21 Dec 2016 18:11:11 +0100
 
-python-xtd (0.5.6) unstable; urgency=medium
+xtdpy (0.5.6) unstable; urgency=medium
 
   * Initial release
 

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 7.0.50), debhelper (>= 9~), python3-all (>= 3.4),
     python3-setuptools, python3-cherrypy3, python3-termcolor, python3-pycurl
 X-Python3-Version: >= 3.4
 
-Package: python-xtd
+Package: python3-xtd
 Architecture: all
 Depends: ${python3:Depends}, ${misc:Depends}
 Description: A high level Python development library.

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,8 @@ Section: utils
 Priority: optional
 Maintainer: Xavier MARCELET <xavier@marcelet.com>
 Build-Depends: debhelper (>= 7.0.50), debhelper (>= 9~), python3-all (>= 3.4),
-    python3-setuptools, python3-cherrypy3, python3-termcolor, python3-pycurl
+    python3-setuptools, python3-cherrypy3, python3-termcolor, python3-pycurl,
+    python3-requests
 X-Python3-Version: >= 3.4
 
 Package: python3-xtd

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: python-xtd
+Source: xtdpy
 Section: utils
 Priority: optional
 Maintainer: Xavier MARCELET <xavier@marcelet.com>

--- a/debian/rules
+++ b/debian/rules
@@ -9,11 +9,11 @@
 override_dh_auto_test:
 
 override_dh_auto_clean:
-	python setup.py clean -a
+	python3 setup.py clean -a
 	find . -name \*.pyc -exec rm {} \;
 
 override_dh_auto_build:
-	python setup.py build --force
+	python3 setup.py build --force
 
 override_dh_auto_install:
-	python setup.py install --force --root=debian/python-xtd --no-compile -O0 --install-layout=deb
+	python3 setup.py install --force --root=debian/python3-xtd --no-compile -O0 --install-layout=deb

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -6,3 +6,4 @@ coveralls
 pylint
 sphinx
 sphinx_rtd_theme
+requests

--- a/requirements.rtd.txt
+++ b/requirements.rtd.txt
@@ -4,3 +4,4 @@ coveralls
 pylint
 sphinx
 sphinx_rtd_theme
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ cherrypy
 termcolor
 pycurl
 coveralls
-
+requests

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
               'xtd.core.logger',     'xtd.core.config', 'xtd.network.client',
               'xtd.network.server'],
   install_requires = ["cherrypy", "termcolor", "pycurl", "requests"],
+  test_suite   = 'xtd.test',
   version      = xtd.__version__,
   description  = xtd.__description__,
   author       = xtd.__author__.split("<")[0].strip(),

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ __author__    = "Xavier MARCELET <xavier@marcelet.com>"
 #------------------------------------------------------------------#
 
 import sys
-from distutils.core import setup
+from setuptools import setup
 sys.path.insert(0, ".")
 import xtd
 
@@ -17,6 +17,7 @@ setup(
               'xtd.core.param',      'xtd.core.stat',   'xtd.core.tools',
               'xtd.core.logger',     'xtd.core.config', 'xtd.network.client',
               'xtd.network.server'],
+  install_requires = ["cherrypy", "termcolor", "pycurl", "requests"],
   version      = xtd.__version__,
   description  = xtd.__description__,
   author       = xtd.__author__.split("<")[0].strip(),


### PR DESCRIPTION
Hello

Here are some few updates related to debian package building.

* dependencies have been updated and fixed
* setup.py has been modified to use distutils in order to allow dh_python to automatically generate the list of runtime dependencies.
* debian/rules has been modified to use python3.
* source package has been renamed xtdpy
* binary package has been renamed python3-xtd

The build has been tested on ubuntu trusty and xenial.